### PR TITLE
Tolto link a slack

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -24,8 +24,6 @@
           <span><a href="https://plus.google.com/u/0/b/111537749545250109648/111537749545250109648/posts"><img src="/assets/plus-icon.svg"></a></span>
           <span><a href="https://github.com/GdgMilano"><img src="/assets/github-icon.svg"></a></span>
           <span><a href="https://www.facebook.com/GDGMilano"><img src="/assets/facebook-icon.svg"></a></span>
-        <br /><br />
-        <script async defer src="https://gdgmilanoslack.herokuapp.com/slackin.js"></script>
       </div>
       <div class="col-md-3 sponsor bottom">
         <h4>Sponsored by:</h4>


### PR DESCRIPTION
Visto che ora slack viene usato solo dallo staff e' meglio non averlo linkato